### PR TITLE
로그인 버그 수정 및 권한 확인 로직 추가

### DIFF
--- a/src/main/java/pulleydoreurae/careerquestbackend/auth/domain/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/pulleydoreurae/careerquestbackend/auth/domain/jwt/filter/JwtAuthenticationFilter.java
@@ -23,6 +23,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import pulleydoreurae.careerquestbackend.auth.domain.CustomUserDetails;
 import pulleydoreurae.careerquestbackend.auth.domain.entity.UserAccount;
 import pulleydoreurae.careerquestbackend.auth.domain.jwt.JwtTokenProvider;
+import pulleydoreurae.careerquestbackend.auth.domain.jwt.dto.JwtTokenResponse;
 import pulleydoreurae.careerquestbackend.auth.domain.jwt.entity.JwtAccessToken;
 import pulleydoreurae.careerquestbackend.auth.domain.jwt.entity.JwtRefreshToken;
 import pulleydoreurae.careerquestbackend.auth.domain.jwt.repository.JwtAccessTokenRepository;
@@ -115,10 +116,14 @@ public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
 			Optional<JwtRefreshToken> jwtRefreshToken = jwtRefreshTokenRepository.findById(userId);
 			if (jwtRefreshToken.isPresent() && refreshToken.equals(jwtRefreshToken.get().getRefreshToken())) {
 				// 리프레시 토큰이 저장되어 있고 전달받은 리프레시 토큰이 일치한다면 새로운 액세스 토큰을 반환
+				JwtTokenResponse jwtTokenResponse = jwtTokenProvider.refreshAccessToken(refreshToken);
+				JwtAccessToken newAccessToken = new JwtAccessToken(userId, jwtTokenResponse.getAccess_token());
+				jwtAccessTokenRepository.save(newAccessToken);
+
 				response.setStatus(HttpStatus.OK.value());
 				response.setContentType("application/json;charset=UTF-8");
 				response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-				response.getWriter().write(gson.toJson(jwtTokenProvider.refreshAccessToken(refreshToken)));
+				response.getWriter().write(gson.toJson(jwtTokenResponse));
 				return;
 			}
 			// 리프레시 토큰이 만료되어 없거나 일치하지 않는다면

--- a/src/main/java/pulleydoreurae/careerquestbackend/certification/service/CommonReviewService.java
+++ b/src/main/java/pulleydoreurae/careerquestbackend/certification/service/CommonReviewService.java
@@ -5,7 +5,6 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import jakarta.servlet.http.Cookie;
@@ -14,7 +13,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import pulleydoreurae.careerquestbackend.auth.domain.entity.UserAccount;
-import pulleydoreurae.careerquestbackend.auth.repository.UserAccountRepository;
 import pulleydoreurae.careerquestbackend.certification.domain.dto.request.ReviewRequest;
 import pulleydoreurae.careerquestbackend.certification.domain.dto.response.ReviewResponse;
 import pulleydoreurae.careerquestbackend.certification.domain.entity.Review;
@@ -37,7 +35,6 @@ import pulleydoreurae.careerquestbackend.community.exception.PostNotFoundExcepti
 @RequiredArgsConstructor
 public class CommonReviewService {
 
-	private final UserAccountRepository userAccountRepository;
 	private final ReviewRepository reviewRepository;
 	private final ReviewLikeRepository reviewLikeRepository;
 	private final ReviewViewCheckRepository reviewViewCheckRepository;
@@ -56,23 +53,6 @@ public class CommonReviewService {
 			throw new PostNotFoundException("요청한 후기 정보를 찾을 수 없습니다.");
 		}
 		return findPost.get();
-	}
-
-	/**
-	 * 회원아이디로 회원정보를 찾아오는 메서드
-	 *
-	 * @param userId 회원아이디
-	 * @return 해당하는 회원정보가 있으면 회원정보를, 없다면 null 리턴
-	 */
-	public UserAccount findUserAccount(String userId) {
-		Optional<UserAccount> findUser = userAccountRepository.findByUserId(userId);
-
-		// 회원정보를 찾을 수 없다면
-		if (findUser.isEmpty()) {
-			log.error("{} 의 회원 정보를 찾을 수 없습니다.", userId);
-			throw new UsernameNotFoundException("요청한 회원 정보를 찾을 수 없습니다.");
-		}
-		return findUser.get();
 	}
 
 	/**

--- a/src/main/java/pulleydoreurae/careerquestbackend/certification/service/ReviewLikeService.java
+++ b/src/main/java/pulleydoreurae/careerquestbackend/certification/service/ReviewLikeService.java
@@ -13,6 +13,7 @@ import pulleydoreurae.careerquestbackend.certification.domain.dto.response.Revie
 import pulleydoreurae.careerquestbackend.certification.domain.entity.Review;
 import pulleydoreurae.careerquestbackend.certification.domain.entity.ReviewLike;
 import pulleydoreurae.careerquestbackend.certification.repository.ReviewLikeRepository;
+import pulleydoreurae.careerquestbackend.common.service.CommonService;
 
 /**
  * 자격증 좋아요 서비스 구현체
@@ -26,6 +27,7 @@ public class ReviewLikeService {
 
 	private final CommonReviewService commonReviewService;
 	private final ReviewLikeRepository reviewLikeRepository;
+	private final CommonService commonService;
 
 	/**
 	 * 좋아요 상태를 변경하는 메서드
@@ -33,7 +35,7 @@ public class ReviewLikeService {
 	 * @param reviewLikeRequest 좋아요 요청 (isLiked 가 0일땐 증가, 1일땐 감소)
 	 */
 	public void changeReviewLike(ReviewLikeRequest reviewLikeRequest) {
-		UserAccount user = commonReviewService.findUserAccount(reviewLikeRequest.getUserId());
+		UserAccount user = commonService.findUserAccount(reviewLikeRequest.getUserId(), true);
 		Review review = commonReviewService.findReview(reviewLikeRequest.getReviewId());
 
 		if (reviewLikeRequest.getIsLiked()) { // 감소
@@ -53,7 +55,7 @@ public class ReviewLikeService {
 	 * @return 게시글 리스트
 	 */
 	public List<ReviewResponse> findAllReviewLikeByUserAccount(String userId, Pageable pageable) {
-		UserAccount user = commonReviewService.findUserAccount(userId);
+		UserAccount user = commonService.findUserAccount(userId, false);
 		List<ReviewResponse> list = new ArrayList<>();
 
 		reviewLikeRepository.findAllByUserAccountOrderByIdDesc(user, pageable)

--- a/src/main/java/pulleydoreurae/careerquestbackend/certification/service/ReviewService.java
+++ b/src/main/java/pulleydoreurae/careerquestbackend/certification/service/ReviewService.java
@@ -20,6 +20,7 @@ import pulleydoreurae.careerquestbackend.certification.domain.entity.ReviewViewC
 import pulleydoreurae.careerquestbackend.certification.repository.ReviewLikeRepository;
 import pulleydoreurae.careerquestbackend.certification.repository.ReviewRepository;
 import pulleydoreurae.careerquestbackend.certification.repository.ReviewViewCheckRepository;
+import pulleydoreurae.careerquestbackend.common.service.CommonService;
 
 /**
  * 자격증 후기 서비스 구현체
@@ -36,6 +37,7 @@ public class ReviewService {
 	private final ReviewRepository reviewRepository;
 	private final ReviewLikeRepository reviewLikeRepository;
 	private final ReviewViewCheckRepository reviewViewCheckRepository;
+	private final CommonService commonService;
 
 	/**
 	 * 후기 리스트를 불러오는 메서드
@@ -68,7 +70,7 @@ public class ReviewService {
 	 * @return 회원정보에 맞는 리스트 반환
 	 */
 	public List<ReviewResponse> getReviewListByUserAccount(String userId, Pageable pageable) {
-		UserAccount user = commonReviewService.findUserAccount(userId);
+		UserAccount user = commonService.findUserAccount(userId, false);
 
 		return commonReviewService.reviewListToReviewResponseList(
 				reviewRepository.findAllByUserAccountOrderByIdDesc(user, pageable));
@@ -147,7 +149,7 @@ public class ReviewService {
 	 */
 	public Boolean getIsLiked(String userId, Review review) {
 		// userId 로 회원을 가져온다.
-		UserAccount user = commonReviewService.findUserAccount(userId);
+		UserAccount user = commonService.findUserAccount(userId, false);
 		// user 가 null 이거나 좋아요 누른 정보를 가져올 수 없다면 false, 눌렀다면 true
 		return reviewLikeRepository.existsByReviewAndUserAccount(review, user);
 	}
@@ -158,7 +160,7 @@ public class ReviewService {
 	 * @param reviewRequest 게시글 요청
 	 */
 	public void saveReview(ReviewRequest reviewRequest) {
-		UserAccount user = commonReviewService.findUserAccount(reviewRequest.getUserId());
+		UserAccount user = commonService.findUserAccount(reviewRequest.getUserId(), true);
 		Review review = commonReviewService.reviewRequestToReview(reviewRequest, user);
 		reviewRepository.save(review);
 	}
@@ -172,7 +174,7 @@ public class ReviewService {
 	 */
 	public boolean updatePost(Long reviewId, ReviewRequest reviewRequest) {
 		Review review = commonReviewService.findReview(reviewId);
-		UserAccount user = commonReviewService.findUserAccount(reviewRequest.getUserId());
+		UserAccount user = commonService.findUserAccount(reviewRequest.getUserId(), true);
 		// 작성자와 수정자가 다르다면 실패
 		if (!review.getUserAccount().getUserId().equals(user.getUserId())) {
 			return false;
@@ -192,7 +194,7 @@ public class ReviewService {
 	 * @return 삭제 요청이 성공이면 true 실패하면 false
 	 */
 	public boolean deleteReview(Long reviewId, String userId) {
-		UserAccount user = commonReviewService.findUserAccount(userId);
+		UserAccount user = commonService.findUserAccount(userId, true);
 		Review review = commonReviewService.findReview(reviewId);
 		// 작성자와 요청자가 다르다면 실패 (권한 없음)
 		if (!review.getUserAccount().getUserId().equals(user.getUserId())) {

--- a/src/main/java/pulleydoreurae/careerquestbackend/common/exception/CommonControllerAdvice.java
+++ b/src/main/java/pulleydoreurae/careerquestbackend/common/exception/CommonControllerAdvice.java
@@ -30,7 +30,7 @@ public class CommonControllerAdvice {
 	}
 
 	@ExceptionHandler({UsernameNotFoundException.class, CommunityException.class, MalformedURLException.class,
-			IllegalArgumentException.class})
+			IllegalArgumentException.class, IllegalAccessError.class})
 	public ResponseEntity<SimpleResponse> community(Exception e) {
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
 				.body(SimpleResponse.builder().msg(e.getMessage()).build());

--- a/src/main/java/pulleydoreurae/careerquestbackend/common/service/CommonService.java
+++ b/src/main/java/pulleydoreurae/careerquestbackend/common/service/CommonService.java
@@ -1,0 +1,69 @@
+package pulleydoreurae.careerquestbackend.common.service;
+
+import java.util.Optional;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import pulleydoreurae.careerquestbackend.auth.domain.entity.UserAccount;
+import pulleydoreurae.careerquestbackend.auth.repository.UserAccountRepository;
+
+/**
+ * 자주 사용되는 메서드를 묶은 Service
+ *
+ * @author : parkjihyeok
+ * @since : 2024/05/28
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CommonService {
+
+	private final UserAccountRepository userAccountRepository;
+
+	/**
+	 * 회원아이디로 회원정보를 찾아오는 메서드
+	 *
+	 * @param userId    회원아이디
+	 * @param checkAuth 요청자의 권한확인 요청 (true -> 권한확인, false -> 권한확인 X)
+	 * @return 해당하는 회원정보가 있으면 회원정보를, 없다면 null 리턴
+	 */
+	public UserAccount findUserAccount(String userId, boolean checkAuth) {
+
+		if (checkAuth) { // 권한확인 요청이 들어오면
+			checkAuth(userId);
+		}
+		Optional<UserAccount> findUser = userAccountRepository.findByUserId(userId);
+
+		// 회원정보를 찾을 수 없다면
+		if (findUser.isEmpty()) {
+			log.error("{} 의 회원 정보를 찾을 수 없습니다.", userId);
+			throw new UsernameNotFoundException("요청한 회원 정보를 찾을 수 없습니다.");
+		}
+		return findUser.get();
+	}
+
+	/**
+	 * 요청자가 접근 권한이 있는지 확인하는 메서드
+	 *
+	 * @param userId 요청자가 가지고 있어야하는 userId
+	 */
+	public void checkAuth(String userId) {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		if (authentication != null && authentication.isAuthenticated()) {
+			Object principal = authentication.getPrincipal();
+			if (principal instanceof UserDetails) {
+				if (!userId.equals(((UserDetails)principal).getUsername())) { // 요청자가 권한이 없다면
+					throw new IllegalAccessError("요청자의 권한을 확인할 수 없습니다.");
+				}
+			} else { // 시큐리티에서 권한을 꺼낼 수 없다면
+				throw new IllegalAccessError("요청자의 권한을 확인할 수 없습니다.");
+			}
+		}
+	}
+}

--- a/src/main/java/pulleydoreurae/careerquestbackend/community/service/CommentService.java
+++ b/src/main/java/pulleydoreurae/careerquestbackend/community/service/CommentService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import pulleydoreurae.careerquestbackend.auth.domain.entity.UserAccount;
+import pulleydoreurae.careerquestbackend.common.service.CommonService;
 import pulleydoreurae.careerquestbackend.community.domain.dto.request.CommentRequest;
 import pulleydoreurae.careerquestbackend.community.domain.dto.response.CommentResponse;
 import pulleydoreurae.careerquestbackend.community.domain.entity.Comment;
@@ -25,6 +26,7 @@ public class CommentService {
 
 	private final CommentRepository commentRepository;
 	private final CommonCommunityService commonCommunityService;
+	private final CommonService commonService;
 
 	/**
 	 * 댓글 저장 메서드
@@ -32,7 +34,7 @@ public class CommentService {
 	 * @param commentRequest 댓글 요청
 	 */
 	public void saveComment(CommentRequest commentRequest) {
-		UserAccount user = commonCommunityService.findUserAccount(commentRequest.getUserId());
+		UserAccount user = commonService.findUserAccount(commentRequest.getUserId(), true);
 		Post post = commonCommunityService.findPost(commentRequest.getPostId());
 		Comment comment = commentRequestToComment(commentRequest, user, post);
 		commentRepository.save(comment);
@@ -46,7 +48,7 @@ public class CommentService {
 	 * @return 수정에 성공하면 true, 실패하면 false
 	 */
 	public boolean updateComment(CommentRequest commentRequest, Long commentId) {
-		UserAccount user = commonCommunityService.findUserAccount(commentRequest.getUserId());
+		UserAccount user = commonService.findUserAccount(commentRequest.getUserId(), true);
 		Post post = commonCommunityService.findPost(commentRequest.getPostId());
 		Comment comment = commonCommunityService.findComment(commentId);
 
@@ -70,7 +72,7 @@ public class CommentService {
 	 * @return 삭제에 성공하면 true, 실패하면 false
 	 */
 	public boolean deleteComment(Long commentId, Long postId, String userId) {
-		UserAccount user = commonCommunityService.findUserAccount(userId);
+		UserAccount user = commonService.findUserAccount(userId, true);
 		Post post = commonCommunityService.findPost(postId);
 		Comment comment = commonCommunityService.findComment(commentId);
 
@@ -111,7 +113,7 @@ public class CommentService {
 	 * @return 댓글 리스트
 	 */
 	public List<CommentResponse> findListByUserAccount(String userId, Pageable pageable) {
-		UserAccount user = commonCommunityService.findUserAccount(userId);
+		UserAccount user = commonService.findUserAccount(userId, false);
 		return commentRepository.findAllByUserAccountOrderByIdDesc(user, pageable).stream()
 				.map(comment -> CommentResponse.builder()
 						.userId(comment.getUserAccount().getUserId())

--- a/src/main/java/pulleydoreurae/careerquestbackend/community/service/CommonCommunityService.java
+++ b/src/main/java/pulleydoreurae/careerquestbackend/community/service/CommonCommunityService.java
@@ -6,7 +6,6 @@ import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import jakarta.servlet.http.Cookie;
@@ -15,7 +14,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import pulleydoreurae.careerquestbackend.auth.domain.entity.UserAccount;
-import pulleydoreurae.careerquestbackend.auth.repository.UserAccountRepository;
 import pulleydoreurae.careerquestbackend.community.domain.dto.request.PostRequest;
 import pulleydoreurae.careerquestbackend.community.domain.dto.response.PostResponse;
 import pulleydoreurae.careerquestbackend.community.domain.entity.Comment;
@@ -43,7 +41,6 @@ import pulleydoreurae.careerquestbackend.community.repository.PostViewCheckRepos
 public class CommonCommunityService {
 
 	private final PostRepository postRepository;
-	private final UserAccountRepository userAccountRepository;
 	private final PostViewCheckRepository postViewCheckRepository;
 	private final CommentRepository commentRepository;
 	private final PostLikeRepository postLikeRepository;
@@ -118,23 +115,6 @@ public class CommonCommunityService {
 			throw new CommentNotFoundException("요청한 댓글 정보를 찾을 수 없습니다.");
 		}
 		return optionalComment.get();
-	}
-
-	/**
-	 * 회원아이디로 회원정보를 찾아오는 메서드
-	 *
-	 * @param userId 회원아이디
-	 * @return 해당하는 회원정보가 있으면 회원정보를, 없다면 null 리턴
-	 */
-	public UserAccount findUserAccount(String userId) {
-		Optional<UserAccount> findUser = userAccountRepository.findByUserId(userId);
-
-		// 회원정보를 찾을 수 없다면
-		if (findUser.isEmpty()) {
-			log.error("{} 의 회원 정보를 찾을 수 없습니다.", userId);
-			throw new UsernameNotFoundException("요청한 회원 정보를 찾을 수 없습니다.");
-		}
-		return findUser.get();
 	}
 
 	/**

--- a/src/main/java/pulleydoreurae/careerquestbackend/community/service/PostLikeService.java
+++ b/src/main/java/pulleydoreurae/careerquestbackend/community/service/PostLikeService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import pulleydoreurae.careerquestbackend.auth.domain.entity.UserAccount;
+import pulleydoreurae.careerquestbackend.common.service.CommonService;
 import pulleydoreurae.careerquestbackend.community.domain.dto.request.PostLikeRequest;
 import pulleydoreurae.careerquestbackend.community.domain.dto.response.PostResponse;
 import pulleydoreurae.careerquestbackend.community.domain.entity.Post;
@@ -26,6 +27,7 @@ public class PostLikeService {
 
 	private final PostLikeRepository postLikeRepository;
 	private final CommonCommunityService commonCommunityService;
+	private final CommonService commonService;
 
 	/**
 	 * 좋아요 상태를 변경하는 메서드
@@ -33,7 +35,7 @@ public class PostLikeService {
 	 * @param postLikeRequest 좋아요 요청 (isLiked 가 false 일땐 추가, true 일땐 제거)
 	 */
 	public void changePostLike(PostLikeRequest postLikeRequest) {
-		UserAccount user = commonCommunityService.findUserAccount(postLikeRequest.getUserId());
+		UserAccount user = commonService.findUserAccount(postLikeRequest.getUserId(), true);
 		Post post = commonCommunityService.findPost(postLikeRequest.getPostId());
 
 		if (postLikeRequest.getIsLiked()) { // 좋아요 제거
@@ -53,7 +55,7 @@ public class PostLikeService {
 	 * @return 게시글 리스트
 	 */
 	public List<PostResponse> findAllPostLikeByUserAccount(String userId, Pageable pageable) {
-		UserAccount user = commonCommunityService.findUserAccount(userId);
+		UserAccount user = commonService.findUserAccount(userId, false);
 		List<PostResponse> list = new ArrayList<>();
 
 		postLikeRepository.findAllByUserAccountOrderByIdDesc(user, pageable)

--- a/src/test/java/pulleydoreurae/careerquestbackend/certification/service/CommonReviewServiceTest.java
+++ b/src/test/java/pulleydoreurae/careerquestbackend/certification/service/CommonReviewServiceTest.java
@@ -15,10 +15,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 import pulleydoreurae.careerquestbackend.auth.domain.entity.UserAccount;
-import pulleydoreurae.careerquestbackend.auth.repository.UserAccountRepository;
 import pulleydoreurae.careerquestbackend.certification.domain.dto.request.ReviewRequest;
 import pulleydoreurae.careerquestbackend.certification.domain.dto.response.ReviewResponse;
 import pulleydoreurae.careerquestbackend.certification.domain.entity.Review;
@@ -40,8 +38,6 @@ class CommonReviewServiceTest {
 
 	@InjectMocks
 	CommonReviewService commonReviewService;
-	@Mock
-	UserAccountRepository userAccountRepository;
 	@Mock
 	ReviewRepository reviewRepository;
 	@Mock
@@ -148,31 +144,6 @@ class CommonReviewServiceTest {
 		);
 	}
 
-	@Test
-	@DisplayName("사용자 찾기 실패")
-	void findUserAccountFailTest() {
-		// Given
-		given(userAccountRepository.findByUserId("testId")).willReturn(Optional.empty());
-
-		// When
-
-		// Then
-		assertThrows(UsernameNotFoundException.class, () -> commonReviewService.findUserAccount("testId"));
-	}
-
-	@Test
-	@DisplayName("사용자 찾기 성공")
-	void findUserAccountSuccessTest() {
-		// Given
-		UserAccount user = UserAccount.builder().userId("testId").build();
-		given(userAccountRepository.findByUserId("testId")).willReturn(Optional.of(user));
-
-		// When
-		UserAccount result = commonReviewService.findUserAccount("testId");
-
-		// Then
-		assertEquals(user, result);
-	}
 
 	@Test
 	@DisplayName("조회수 중복이 아닌 경우")

--- a/src/test/java/pulleydoreurae/careerquestbackend/certification/service/ReviewLikeServiceTest.java
+++ b/src/test/java/pulleydoreurae/careerquestbackend/certification/service/ReviewLikeServiceTest.java
@@ -24,6 +24,7 @@ import pulleydoreurae.careerquestbackend.certification.domain.dto.response.Revie
 import pulleydoreurae.careerquestbackend.certification.domain.entity.Review;
 import pulleydoreurae.careerquestbackend.certification.domain.entity.ReviewLike;
 import pulleydoreurae.careerquestbackend.certification.repository.ReviewLikeRepository;
+import pulleydoreurae.careerquestbackend.common.service.CommonService;
 import pulleydoreurae.careerquestbackend.community.exception.PostNotFoundException;
 
 /**
@@ -40,6 +41,8 @@ class ReviewLikeServiceTest {
 	ReviewLikeRepository reviewLikeRepository;
 	@Mock
 	CommonReviewService commonReviewService;
+	@Mock
+	CommonService commonService;
 
 	@Test
 	@DisplayName("좋아요 증가 테스트 (실패 - 회원정보를 찾을 수 없음)")
@@ -47,7 +50,7 @@ class ReviewLikeServiceTest {
 		// Given
 		UserAccount user = UserAccount.builder().userId("testId").build();
 
-		given(commonReviewService.findUserAccount("testId"))
+		given(commonService.findUserAccount("testId", true))
 				.willThrow(new UsernameNotFoundException("사용자 정보를 찾을 수 없습니다."));
 
 		// When
@@ -65,7 +68,7 @@ class ReviewLikeServiceTest {
 		// Given
 		UserAccount user = UserAccount.builder().userId("testId").build();
 
-		given(commonReviewService.findUserAccount("testId")).willReturn(user);
+		given(commonService.findUserAccount("testId", true)).willReturn(user);
 		given(commonReviewService.findReview(10000L))
 				.willThrow(new PostNotFoundException("후기 정보를 찾을 수 없습니다."));
 
@@ -85,7 +88,7 @@ class ReviewLikeServiceTest {
 		UserAccount user = UserAccount.builder().userId("testId").build();
 		Review review = Review.builder().userAccount(user).id(10000L).title("제목1").build();
 
-		given(commonReviewService.findUserAccount("testId")).willReturn(user);
+		given(commonService.findUserAccount("testId", true)).willReturn(user);
 		given(commonReviewService.findReview(10000L)).willReturn(review);
 
 		// When
@@ -104,7 +107,7 @@ class ReviewLikeServiceTest {
 		// Given
 		UserAccount user = UserAccount.builder().userId("testId").build();
 
-		given(commonReviewService.findUserAccount("testId"))
+		given(commonService.findUserAccount("testId", true))
 				.willThrow(new UsernameNotFoundException("사용자 정보를 찾을 수 없습니다."));
 
 		// When
@@ -122,7 +125,7 @@ class ReviewLikeServiceTest {
 		// Given
 		UserAccount user = UserAccount.builder().userId("testId").build();
 
-		given(commonReviewService.findUserAccount("testId")).willReturn(user);
+		given(commonService.findUserAccount("testId", true)).willReturn(user);
 		given(commonReviewService.findReview(10000L))
 				.willThrow(new PostNotFoundException("게시글 정보를 찾을 수 없습니다."));
 
@@ -142,7 +145,7 @@ class ReviewLikeServiceTest {
 		Review review = Review.builder().userAccount(user).id(10000L).title("제목1").build();
 		ReviewLike reviewLike = ReviewLike.builder().userAccount(user).review(review).build();
 
-		given(commonReviewService.findUserAccount("testId")).willReturn(user);
+		given(commonService.findUserAccount("testId", true)).willReturn(user);
 		given(commonReviewService.findReview(10000L)).willReturn(review);
 		given(commonReviewService.findReviewLike(review, user)).willReturn(reviewLike);
 
@@ -176,7 +179,7 @@ class ReviewLikeServiceTest {
 		Page<ReviewLike> list = new PageImpl<>(
 				List.of(reviewLike3, reviewLike4, reviewLike5), pageable, 3); // 3개씩 자른다면 마지막 3개가 반환되어야 함
 
-		given(commonReviewService.findUserAccount("testId")).willReturn(user);
+		given(commonService.findUserAccount("testId", false)).willReturn(user);
 		given(commonReviewService.reviewToReviewResponse(review3, false)).willReturn(reviewToReviewResponse(review3));
 		given(commonReviewService.reviewToReviewResponse(review4, false)).willReturn(reviewToReviewResponse(review4));
 		given(commonReviewService.reviewToReviewResponse(review5, false)).willReturn(reviewToReviewResponse(review5));

--- a/src/test/java/pulleydoreurae/careerquestbackend/certification/service/ReviewServiceTest.java
+++ b/src/test/java/pulleydoreurae/careerquestbackend/certification/service/ReviewServiceTest.java
@@ -28,6 +28,7 @@ import pulleydoreurae.careerquestbackend.certification.domain.entity.ReviewViewC
 import pulleydoreurae.careerquestbackend.certification.repository.ReviewLikeRepository;
 import pulleydoreurae.careerquestbackend.certification.repository.ReviewRepository;
 import pulleydoreurae.careerquestbackend.certification.repository.ReviewViewCheckRepository;
+import pulleydoreurae.careerquestbackend.common.service.CommonService;
 import pulleydoreurae.careerquestbackend.community.exception.PostNotFoundException;
 
 /**
@@ -48,6 +49,8 @@ class ReviewServiceTest {
 	ReviewViewCheckRepository reviewViewCheckRepository;
 	@Mock
 	CommonReviewService commonReviewService;
+	@Mock
+	CommonService commonService;
 
 	@Test
 	@DisplayName("후기 불러오기 실패")
@@ -165,7 +168,7 @@ class ReviewServiceTest {
 	void saveReviewSuccessTest() {
 		// Given
 		UserAccount user = UserAccount.builder().userId("testId").build();
-		given(commonReviewService.findUserAccount("testId")).willReturn(user);
+		given(commonService.findUserAccount("testId", true)).willReturn(user);
 
 		// When
 
@@ -177,7 +180,7 @@ class ReviewServiceTest {
 	@DisplayName("후기 등록 테스트 (실패)")
 	void saveReviewFailTest() {
 		// Given
-		given(commonReviewService.findUserAccount("testId")).willThrow(UsernameNotFoundException.class);
+		given(commonService.findUserAccount("testId", true)).willThrow(UsernameNotFoundException.class);
 
 		// When
 
@@ -208,7 +211,7 @@ class ReviewServiceTest {
 		UserAccount user = UserAccount.builder().userId("testId").build();
 		Review review = Review.builder().title("제목").content("내용").userAccount(user).view(1L).certificationName("정보처리기사").build();
 		given(commonReviewService.findReview(any())).willReturn(review);
-		given(commonReviewService.findUserAccount(any()))
+		given(commonService.findUserAccount(any(), anyBoolean()))
 				.willThrow(new UsernameNotFoundException("사용자 정보를 찾을 수 없습니다."));
 
 		// When
@@ -228,7 +231,7 @@ class ReviewServiceTest {
 		UserAccount user2 = UserAccount.builder().userId("testId2").build();
 		Review review = Review.builder().title("제목").content("내용").userAccount(user1).view(1L).certificationName("정보처리기사").build();
 		given(commonReviewService.findReview(any())).willReturn(review);
-		given(commonReviewService.findUserAccount(any())).willReturn(user2);
+		given(commonService.findUserAccount(any(), anyBoolean())).willReturn(user2);
 
 		// When
 		boolean result = reviewService.updatePost(100L, new ReviewRequest("testId", "정보처리기사", "제목", "내용"));
@@ -246,7 +249,7 @@ class ReviewServiceTest {
 		UserAccount user = UserAccount.builder().userId("testId").build();
 		Review review = Review.builder().title("제목").content("내용").userAccount(user).view(1L).certificationName("정보처리기사").build();
 		given(commonReviewService.findReview(any())).willReturn(review);
-		given(commonReviewService.findUserAccount(any())).willReturn(user);
+		given(commonService.findUserAccount(any(), anyBoolean())).willReturn(user);
 
 		// When
 		boolean result = reviewService.updatePost(100L, new ReviewRequest("testId", "정보처리기사", "제목", "내용"));
@@ -274,7 +277,7 @@ class ReviewServiceTest {
 	@DisplayName("후기 삭제 실패 (사용자 찾을 수 없음)")
 	void deleteReviewFail2Test() {
 		// Given
-		given(commonReviewService.findUserAccount("testId"))
+		given(commonService.findUserAccount("testId", true))
 				.willThrow(new UsernameNotFoundException("사용자 정보를 찾을 수 없습니다."));
 
 		// When
@@ -291,7 +294,7 @@ class ReviewServiceTest {
 		UserAccount user = UserAccount.builder().userId("testId").build();
 		Review review = Review.builder().title("제목").content("내용").userAccount(user).view(1L).certificationName("정보처리기사").build();
 		given(commonReviewService.findReview(100L)).willReturn(review);
-		given(commonReviewService.findUserAccount("testId1"))
+		given(commonService.findUserAccount("testId1", true))
 				.willReturn(UserAccount.builder().userId("testId1").build());
 
 		// When
@@ -310,7 +313,7 @@ class ReviewServiceTest {
 		Review review = Review.builder().title("제목").content("내용").userAccount(user).view(1L).certificationName("정보처리기사").build();
 
 		given(commonReviewService.findReview(any())).willReturn(review);
-		given(commonReviewService.findUserAccount("testId")).willReturn(user);
+		given(commonService.findUserAccount("testId", true)).willReturn(user);
 
 		// When
 		boolean result = reviewService.deleteReview(100L, "testId");

--- a/src/test/java/pulleydoreurae/careerquestbackend/common/service/CommonServiceTest.java
+++ b/src/test/java/pulleydoreurae/careerquestbackend/common/service/CommonServiceTest.java
@@ -1,0 +1,98 @@
+package pulleydoreurae.careerquestbackend.common.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import pulleydoreurae.careerquestbackend.auth.domain.entity.UserAccount;
+import pulleydoreurae.careerquestbackend.auth.repository.UserAccountRepository;
+
+/**
+ * @author : parkjihyeok
+ * @since : 2024/05/28
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("공통으로 자주 사용되는 메서드 테스트")
+class CommonServiceTest {
+
+	@InjectMocks CommonService commonService;
+	@Mock UserAccountRepository userAccountRepository;
+	@Mock SecurityContext securityContext;
+	@Mock Authentication authentication;
+	@Mock UserDetails userDetails;
+
+	@BeforeEach
+	void setUp() {
+		SecurityContextHolder.setContext(securityContext);
+	}
+
+	@Test
+	@DisplayName("사용자 찾기 실패")
+	void findUserAccountFailTest() {
+		// Given
+		given(userAccountRepository.findByUserId("testId")).willReturn(Optional.empty());
+
+		// When
+
+		// Then
+		assertThrows(UsernameNotFoundException.class, () -> commonService.findUserAccount("testId", false));
+	}
+
+	@Test
+	@DisplayName("사용자 찾기 성공")
+	void findUserAccountSuccessTest() {
+		// Given
+		UserAccount user = UserAccount.builder().userId("testId").build();
+		given(userAccountRepository.findByUserId("testId")).willReturn(Optional.of(user));
+
+		// When
+		UserAccount result = commonService.findUserAccount("testId", false);
+
+		// Then
+		assertEquals(user, result);
+	}
+
+	@Test
+	@DisplayName("요청자가 권한이 있는지 테스트 - 실패")
+	void checkAuthTest1() {
+		// Given
+		given(securityContext.getAuthentication()).willReturn(authentication);
+		given(authentication.isAuthenticated()).willReturn(true);
+		given(authentication.getPrincipal()).willReturn(userDetails);
+		given(userDetails.getUsername()).willReturn("testId");
+
+		// When
+
+		// Then
+		assertThrows(IllegalAccessError.class, () -> commonService.checkAuth("testI"));
+	}
+
+	@Test
+	@DisplayName("요청자가 권한이 있는지 테스트 - 성공")
+	void checkAuthTest2() {
+		// Given
+		given(securityContext.getAuthentication()).willReturn(authentication);
+		given(authentication.isAuthenticated()).willReturn(true);
+		given(authentication.getPrincipal()).willReturn(userDetails);
+		given(userDetails.getUsername()).willReturn("testId");
+
+		// When
+
+		// Then
+		assertDoesNotThrow(() -> commonService.checkAuth("testId"));
+	}
+}

--- a/src/test/java/pulleydoreurae/careerquestbackend/community/service/CommentServiceTest.java
+++ b/src/test/java/pulleydoreurae/careerquestbackend/community/service/CommentServiceTest.java
@@ -20,6 +20,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 import pulleydoreurae.careerquestbackend.auth.domain.entity.UserAccount;
+import pulleydoreurae.careerquestbackend.common.service.CommonService;
 import pulleydoreurae.careerquestbackend.community.domain.dto.request.CommentRequest;
 import pulleydoreurae.careerquestbackend.community.domain.dto.response.CommentResponse;
 import pulleydoreurae.careerquestbackend.community.domain.entity.Comment;
@@ -41,6 +42,8 @@ class CommentServiceTest {
 	CommentRepository commentRepository;
 	@Mock
 	CommonCommunityService commonCommunityService;
+	@Mock
+	CommonService commonService;
 
 	@Test
 	@DisplayName("1. 댓글 저장 테스트 (실패 - 회원정보를 찾을 수 없음)")
@@ -50,7 +53,7 @@ class CommentServiceTest {
 		Post post = Post.builder().id(10000L) // 해당 번호까지는 테스트에서 올라갈 일이 없으므로 특정한 값으로 지정해서 정확한 테스트 시도
 				.userAccount(user).title("제목1").build();
 
-		given(commonCommunityService.findUserAccount(user.getUserId()))
+		given(commonService.findUserAccount(user.getUserId(), true))
 				.willThrow(new UsernameNotFoundException("사용자 정보를 찾을 수 없습니다."));
 
 		CommentRequest request = CommentRequest.builder()
@@ -70,7 +73,7 @@ class CommentServiceTest {
 		UserAccount user = UserAccount.builder().userId("testId").build();
 		Post post = Post.builder().id(10000L).userAccount(user).title("제목1").build();
 
-		given(commonCommunityService.findUserAccount(user.getUserId())).willReturn(user);
+		given(commonService.findUserAccount(user.getUserId(), true)).willReturn(user);
 		given(commonCommunityService.findPost(post.getId()))
 				.willThrow(new PostNotFoundException("게시글 정보를 찾을 수 없습니다."));
 
@@ -91,7 +94,7 @@ class CommentServiceTest {
 		UserAccount user = UserAccount.builder().userId("testId").build();
 		Post post = Post.builder().id(10000L).userAccount(user).title("제목1").build();
 
-		given(commonCommunityService.findUserAccount(user.getUserId())).willReturn(user);
+		given(commonService.findUserAccount(user.getUserId(), true)).willReturn(user);
 		given(commonCommunityService.findPost(post.getId())).willReturn(post);
 
 		CommentRequest request = CommentRequest.builder()
@@ -112,7 +115,7 @@ class CommentServiceTest {
 		Post post = Post.builder().id(10000L).userAccount(user).title("제목1").build();
 		Comment comment = Comment.builder().id(10000L).userAccount(user).post(post).content("댓글 내용").build();
 
-		given(commonCommunityService.findUserAccount(user.getUserId()))
+		given(commonService.findUserAccount(user.getUserId(), true))
 				.willThrow(new UsernameNotFoundException("사용자 정보를 찾을 수 없습니다."));
 
 		CommentRequest request = CommentRequest.builder()
@@ -133,7 +136,7 @@ class CommentServiceTest {
 		Post post = Post.builder().id(10000L).userAccount(user).title("제목1").build();
 		Comment comment = Comment.builder().id(10000L).userAccount(user).post(post).content("댓글 내용").build();
 
-		given(commonCommunityService.findUserAccount(user.getUserId())).willReturn(user);
+		given(commonService.findUserAccount(user.getUserId(), true)).willReturn(user);
 		given(commonCommunityService.findPost(post.getId()))
 				.willThrow(new PostNotFoundException("게시글 정보를 찾을 수 없습니다."));
 
@@ -155,7 +158,7 @@ class CommentServiceTest {
 		Post post = Post.builder().id(10000L).userAccount(user).title("제목1").build();
 		Comment comment = Comment.builder().id(10000L).userAccount(user).post(post).content("댓글 내용").build();
 
-		given(commonCommunityService.findUserAccount(user.getUserId())).willReturn(user);
+		given(commonService.findUserAccount(user.getUserId(), true)).willReturn(user);
 		given(commonCommunityService.findPost(post.getId())).willReturn(post);
 		given(commonCommunityService.findComment(comment.getId()))
 				.willThrow(new CommentNotFoundException("댓글정보를 찾을 수 없습니다."));
@@ -178,7 +181,7 @@ class CommentServiceTest {
 		Post post = Post.builder().id(10000L).userAccount(user).title("제목1").build();
 		Comment comment = Comment.builder().id(10000L).userAccount(user).post(post).content("댓글 내용").build();
 
-		given(commonCommunityService.findUserAccount(user.getUserId())).willReturn(user);
+		given(commonService.findUserAccount(user.getUserId(), true)).willReturn(user);
 		given(commonCommunityService.findPost(100L))
 				.willReturn(Post.builder().id(100L).userAccount(user).title("제목1").build());
 		given(commonCommunityService.findComment(comment.getId())).willReturn(comment);
@@ -202,7 +205,7 @@ class CommentServiceTest {
 		Post post = Post.builder().id(10000L).userAccount(user).title("제목1").build();
 		Comment comment = Comment.builder().id(10000L).userAccount(user).post(post).content("댓글 내용").build();
 
-		given(commonCommunityService.findUserAccount("test"))
+		given(commonService.findUserAccount("test", true))
 				.willReturn(UserAccount.builder().userId("test").build());
 		given(commonCommunityService.findPost(post.getId())).willReturn(post);
 		given(commonCommunityService.findComment(comment.getId())).willReturn(comment);
@@ -226,7 +229,7 @@ class CommentServiceTest {
 		Post post = Post.builder().id(10000L).userAccount(user).title("제목1").build();
 		Comment comment = Comment.builder().id(10000L).userAccount(user).post(post).content("댓글 내용").build();
 
-		given(commonCommunityService.findUserAccount(user.getUserId())).willReturn(user);
+		given(commonService.findUserAccount(user.getUserId(), true)).willReturn(user);
 		given(commonCommunityService.findPost(post.getId())).willReturn(post);
 		given(commonCommunityService.findComment(comment.getId())).willReturn(comment);
 
@@ -249,7 +252,7 @@ class CommentServiceTest {
 		Post post = Post.builder().id(10000L).userAccount(user).title("제목1").build();
 		Comment comment = Comment.builder().id(10000L).userAccount(user).post(post).content("댓글 내용").build();
 
-		given(commonCommunityService.findUserAccount(user.getUserId()))
+		given(commonService.findUserAccount(user.getUserId(), true))
 				.willThrow(new UsernameNotFoundException("사용자 정보를 찾을 수 없습니다."));
 
 		// When
@@ -268,7 +271,7 @@ class CommentServiceTest {
 		Post post = Post.builder().id(10000L).userAccount(user).title("제목1").build();
 		Comment comment = Comment.builder().id(10000L).userAccount(user).post(post).content("댓글 내용").build();
 
-		given(commonCommunityService.findUserAccount(user.getUserId())).willReturn(user);
+		given(commonService.findUserAccount(user.getUserId(), true)).willReturn(user);
 		given(commonCommunityService.findPost(post.getId()))
 				.willThrow(new PostNotFoundException("게시글 정보를 찾을 수 없습니다."));
 
@@ -288,7 +291,7 @@ class CommentServiceTest {
 		Post post = Post.builder().id(10000L).userAccount(user).title("제목1").build();
 		Comment comment = Comment.builder().id(10000L).userAccount(user).post(post).content("댓글 내용").build();
 
-		given(commonCommunityService.findUserAccount(user.getUserId())).willReturn(user);
+		given(commonService.findUserAccount(user.getUserId(), true)).willReturn(user);
 		given(commonCommunityService.findPost(post.getId())).willReturn(post);
 		given(commonCommunityService.findComment(comment.getId()))
 				.willThrow(new CommentNotFoundException("댓글정보를 찾을 수 없습니다."));
@@ -309,7 +312,7 @@ class CommentServiceTest {
 		Post post = Post.builder().id(10000L).userAccount(user).title("제목1").build();
 		Comment comment = Comment.builder().id(10000L).userAccount(user).post(post).content("댓글 내용").build();
 
-		given(commonCommunityService.findUserAccount(user.getUserId())).willReturn(user);
+		given(commonService.findUserAccount(user.getUserId(), true)).willReturn(user);
 		given(commonCommunityService.findPost(100L))
 				.willReturn(Post.builder().id(100L).userAccount(user).title("제목1").build());
 		given(commonCommunityService.findComment(comment.getId())).willReturn(comment);
@@ -330,7 +333,7 @@ class CommentServiceTest {
 		Post post = Post.builder().id(10000L).userAccount(user).title("제목1").build();
 		Comment comment = Comment.builder().id(10000L).userAccount(user).post(post).content("댓글 내용").build();
 
-		given(commonCommunityService.findUserAccount("test"))
+		given(commonService.findUserAccount("test", true))
 				.willReturn(UserAccount.builder().userId("test").build());
 		given(commonCommunityService.findPost(post.getId())).willReturn(post);
 		given(commonCommunityService.findComment(comment.getId())).willReturn(comment);
@@ -351,7 +354,7 @@ class CommentServiceTest {
 		Post post = Post.builder().id(10000L).userAccount(user).title("제목1").build();
 		Comment comment = Comment.builder().id(10000L).userAccount(user).post(post).content("댓글 내용").build();
 
-		given(commonCommunityService.findUserAccount(user.getUserId())).willReturn(user);
+		given(commonService.findUserAccount(user.getUserId(), true)).willReturn(user);
 		given(commonCommunityService.findPost(post.getId())).willReturn(post);
 		given(commonCommunityService.findComment(comment.getId())).willReturn(comment);
 
@@ -414,7 +417,7 @@ class CommentServiceTest {
 		Page<Comment> pageList = new PageImpl<>(
 				List.of(comment3, comment4, comment5), pageable, 3);
 
-		given(commonCommunityService.findUserAccount(user.getUserId())).willReturn(user);
+		given(commonService.findUserAccount(user.getUserId(), false)).willReturn(user);
 		given(commentRepository.findAllByUserAccountOrderByIdDesc(user, pageable)).willReturn(pageList);
 
 		// When

--- a/src/test/java/pulleydoreurae/careerquestbackend/community/service/CommonCommunityServiceTest.java
+++ b/src/test/java/pulleydoreurae/careerquestbackend/community/service/CommonCommunityServiceTest.java
@@ -20,6 +20,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 import pulleydoreurae.careerquestbackend.auth.domain.entity.UserAccount;
 import pulleydoreurae.careerquestbackend.auth.repository.UserAccountRepository;
+import pulleydoreurae.careerquestbackend.common.service.CommonService;
 import pulleydoreurae.careerquestbackend.community.domain.PostCategory;
 import pulleydoreurae.careerquestbackend.community.domain.dto.request.PostRequest;
 import pulleydoreurae.careerquestbackend.community.domain.dto.response.PostResponse;
@@ -62,6 +63,8 @@ class CommonCommunityServiceTest {
 	PostImageRepository postImageRepository;
 	@Mock
 	PostViewCheckRepository postViewCheckRepository;
+	@Mock
+	CommonService commonService;
 
 	@Test
 	@DisplayName("게시글 Entity -> 게시글 Response 변환 메서드 테스트")
@@ -209,32 +212,6 @@ class CommonCommunityServiceTest {
 
 		// Then
 		assertEquals(comment, result);
-	}
-
-	@Test
-	@DisplayName("사용자 찾기 실패")
-	void findUserAccountFailTest() {
-		// Given
-		given(userAccountRepository.findByUserId("testId")).willReturn(Optional.empty());
-
-		// When
-
-		// Then
-		assertThrows(UsernameNotFoundException.class, () -> commonCommunityService.findUserAccount("testId"));
-	}
-
-	@Test
-	@DisplayName("사용자 찾기 성공")
-	void findUserAccountSuccessTest() {
-		// Given
-		UserAccount user = UserAccount.builder().userId("testId").build();
-		given(userAccountRepository.findByUserId("testId")).willReturn(Optional.of(user));
-
-		// When
-		UserAccount result = commonCommunityService.findUserAccount("testId");
-
-		// Then
-		assertEquals(user, result);
 	}
 
 	@Test

--- a/src/test/java/pulleydoreurae/careerquestbackend/community/service/PostLikeServiceTest.java
+++ b/src/test/java/pulleydoreurae/careerquestbackend/community/service/PostLikeServiceTest.java
@@ -19,6 +19,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 import pulleydoreurae.careerquestbackend.auth.domain.entity.UserAccount;
+import pulleydoreurae.careerquestbackend.common.service.CommonService;
 import pulleydoreurae.careerquestbackend.community.domain.dto.request.PostLikeRequest;
 import pulleydoreurae.careerquestbackend.community.domain.dto.response.PostResponse;
 import pulleydoreurae.careerquestbackend.community.domain.entity.Post;
@@ -40,6 +41,8 @@ class PostLikeServiceTest {
 	PostLikeRepository postLikeRepository;
 	@Mock
 	CommonCommunityService commonCommunityService;
+	@Mock
+	CommonService commonService;
 
 	@Test
 	@DisplayName("1. 좋아요 증가 테스트 (실패 - 회원정보를 찾을 수 없음)")
@@ -47,7 +50,7 @@ class PostLikeServiceTest {
 		// Given
 		UserAccount user = UserAccount.builder().userId("testId").build();
 
-		given(commonCommunityService.findUserAccount("testId"))
+		given(commonService.findUserAccount("testId", true))
 				.willThrow(new UsernameNotFoundException("사용자 정보를 찾을 수 없습니다."));
 
 		// When
@@ -65,7 +68,7 @@ class PostLikeServiceTest {
 		// Given
 		UserAccount user = UserAccount.builder().userId("testId").build();
 
-		given(commonCommunityService.findUserAccount("testId")).willReturn(user);
+		given(commonService.findUserAccount("testId", true)).willReturn(user);
 		given(commonCommunityService.findPost(10000L))
 				.willThrow(new PostNotFoundException("게시글 정보를 찾을 수 없습니다."));
 
@@ -85,7 +88,7 @@ class PostLikeServiceTest {
 		UserAccount user = UserAccount.builder().userId("testId").build();
 		Post post = Post.builder().userAccount(user).id(10000L).title("제목1").build();
 
-		given(commonCommunityService.findUserAccount("testId")).willReturn(user);
+		given(commonService.findUserAccount("testId", true)).willReturn(user);
 		given(commonCommunityService.findPost(10000L)).willReturn(post);
 
 		// When
@@ -104,7 +107,7 @@ class PostLikeServiceTest {
 		// Given
 		UserAccount user = UserAccount.builder().userId("testId").build();
 
-		given(commonCommunityService.findUserAccount("testId"))
+		given(commonService.findUserAccount("testId", true))
 				.willThrow(new UsernameNotFoundException("사용자 정보를 찾을 수 없습니다."));
 
 		// When
@@ -122,7 +125,7 @@ class PostLikeServiceTest {
 		// Given
 		UserAccount user = UserAccount.builder().userId("testId").build();
 
-		given(commonCommunityService.findUserAccount("testId")).willReturn(user);
+		given(commonService.findUserAccount("testId", true)).willReturn(user);
 		given(commonCommunityService.findPost(10000L))
 				.willThrow(new PostNotFoundException("게시글 정보를 찾을 수 없습니다."));
 
@@ -142,7 +145,7 @@ class PostLikeServiceTest {
 		Post post = Post.builder().userAccount(user).id(10000L).title("제목1").build();
 		PostLike postLike = PostLike.builder().userAccount(user).post(post).build();
 
-		given(commonCommunityService.findUserAccount("testId")).willReturn(user);
+		given(commonService.findUserAccount("testId", true)).willReturn(user);
 		given(commonCommunityService.findPost(10000L)).willReturn(post);
 		given(commonCommunityService.findPostLike(post, user)).willReturn(postLike);
 
@@ -176,7 +179,7 @@ class PostLikeServiceTest {
 		Page<PostLike> list = new PageImpl<>(
 				List.of(postLike3, postLike4, postLike5), pageable, 3); // 3개씩 자른다면 마지막 3개가 반환되어야 함
 
-		given(commonCommunityService.findUserAccount("testId")).willReturn(user);
+		given(commonService.findUserAccount("testId", false)).willReturn(user);
 		given(commonCommunityService.postToPostResponse(post3, false)).willReturn(postToPostResponse(post3));
 		given(commonCommunityService.postToPostResponse(post4, false)).willReturn(postToPostResponse(post4));
 		given(commonCommunityService.postToPostResponse(post5, false)).willReturn(postToPostResponse(post5));

--- a/src/test/java/pulleydoreurae/careerquestbackend/community/service/PostServiceTest.java
+++ b/src/test/java/pulleydoreurae/careerquestbackend/community/service/PostServiceTest.java
@@ -27,6 +27,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import pulleydoreurae.careerquestbackend.auth.domain.entity.UserAccount;
+import pulleydoreurae.careerquestbackend.common.service.CommonService;
 import pulleydoreurae.careerquestbackend.common.service.FileManagementService;
 import pulleydoreurae.careerquestbackend.community.domain.PostCategory;
 import pulleydoreurae.careerquestbackend.community.domain.dto.request.PostRequest;
@@ -66,6 +67,8 @@ class PostServiceTest {
 	FileManagementService fileManagementService;
 	@Mock
 	CommonCommunityService commonCommunityService;
+	@Mock
+	CommonService commonService;
 
 	@Test
 	@DisplayName("게시글 불러오기 실패")
@@ -217,7 +220,7 @@ class PostServiceTest {
 	void savePostSuccessTest() {
 		// Given
 		UserAccount user = UserAccount.builder().userId("testId").build();
-		given(commonCommunityService.findUserAccount("testId")).willReturn(user);
+		given(commonService.findUserAccount("testId", true)).willReturn(user);
 		given(commonCommunityService.postRequestToPost(any(), any())).willReturn(new Post());
 		// When
 
@@ -230,7 +233,7 @@ class PostServiceTest {
 	@DisplayName("게시글 등록 테스트 (실패)")
 	void savePostFailTest() {
 		// Given
-		given(commonCommunityService.findUserAccount("testId")).willThrow(UsernameNotFoundException.class);
+		given(commonService.findUserAccount("testId", true)).willThrow(UsernameNotFoundException.class);
 
 		// When
 
@@ -250,7 +253,7 @@ class PostServiceTest {
 		String image5 = "image5.png";
 		List<String> images = List.of(image1, image2, image3, image4, image5);
 		UserAccount user = UserAccount.builder().userId("testId").build();
-		given(commonCommunityService.findUserAccount("testId")).willReturn(user);
+		given(commonService.findUserAccount("testId", true)).willReturn(user);
 		given(commonCommunityService.postRequestToPost(any(), any())).willReturn(new Post());
 
 		// When
@@ -270,7 +273,7 @@ class PostServiceTest {
 		String image4 = "image4.png";
 		String image5 = "image5.png";
 		List<String> images = List.of(image1, image2, image3, image4, image5);
-		given(commonCommunityService.findUserAccount("testId")).willThrow(UsernameNotFoundException.class);
+		given(commonService.findUserAccount("testId", true)).willThrow(UsernameNotFoundException.class);
 
 		// When
 
@@ -304,7 +307,7 @@ class PostServiceTest {
 		UserAccount user = UserAccount.builder().userId("testId").build();
 		Post post = Post.builder().title("제목").content("내용").userAccount(user).view(1L).postCategory(PostCategory.FREE_BOARD).build();
 		given(commonCommunityService.findPost(any())).willReturn(post);
-		given(commonCommunityService.findUserAccount(any()))
+		given(commonService.findUserAccount(any(), anyBoolean()))
 				.willThrow(new UsernameNotFoundException("사용자 정보를 찾을 수 없습니다."));
 
 		// When
@@ -325,7 +328,7 @@ class PostServiceTest {
 		UserAccount user2 = UserAccount.builder().userId("testId2").build();
 		Post post = Post.builder().title("제목").content("내용").userAccount(user1).view(1L).postCategory(PostCategory.FREE_BOARD).build();
 		given(commonCommunityService.findPost(any())).willReturn(post);
-		given(commonCommunityService.findUserAccount(any())).willReturn(user2);
+		given(commonService.findUserAccount(any(), anyBoolean())).willReturn(user2);
 
 		// When
 
@@ -342,7 +345,7 @@ class PostServiceTest {
 		UserAccount user = UserAccount.builder().userId("testId").build();
 		Post post = Post.builder().title("제목").content("내용").userAccount(user).view(1L).postCategory(PostCategory.FREE_BOARD).build();
 		given(commonCommunityService.findPost(any())).willReturn(post);
-		given(commonCommunityService.findUserAccount(any())).willReturn(user);
+		given(commonService.findUserAccount(any(), anyBoolean())).willReturn(user);
 
 		// When
 
@@ -402,7 +405,7 @@ class PostServiceTest {
 	@DisplayName("게시글 삭제 실패 (사용자 찾을 수 없음)")
 	void deletePostFail2Test() {
 		// Given
-		given(commonCommunityService.findUserAccount("testId"))
+		given(commonService.findUserAccount("testId", true))
 				.willThrow(new UsernameNotFoundException("사용자 정보를 찾을 수 없습니다."));
 
 		// When
@@ -421,7 +424,7 @@ class PostServiceTest {
 		UserAccount user = UserAccount.builder().userId("testId").build();
 		Post post = Post.builder().title("제목").content("내용").userAccount(user).view(1L).postCategory(PostCategory.FREE_BOARD).build();
 		given(commonCommunityService.findPost(100L)).willReturn(post);
-		given(commonCommunityService.findUserAccount("testId1"))
+		given(commonService.findUserAccount("testId1", true))
 				.willReturn(UserAccount.builder().userId("testId1").build());
 
 		// When
@@ -440,7 +443,7 @@ class PostServiceTest {
 		UserAccount user = UserAccount.builder().userId("testId").build();
 		Post post = Post.builder().title("제목").content("내용").userAccount(user).view(1L).postCategory(PostCategory.FREE_BOARD).build();
 		given(commonCommunityService.findPost(any())).willReturn(post);
-		given(commonCommunityService.findUserAccount("testId")).willReturn(user);
+		given(commonService.findUserAccount("testId", true)).willReturn(user);
 		given(postImageRepository.findAllByPost(any())).willReturn(List.of());
 
 		// When
@@ -459,7 +462,7 @@ class PostServiceTest {
 		UserAccount user = UserAccount.builder().userId("testId").build();
 		Post post = Post.builder().title("제목").content("내용").userAccount(user).view(1L).postCategory(PostCategory.FREE_BOARD).build();
 		given(commonCommunityService.findPost(100L)).willReturn(post);
-		given(commonCommunityService.findUserAccount("testId")).willReturn(user);
+		given(commonService.findUserAccount("testId", true)).willReturn(user);
 		given(postImageRepository.findAllByPost(any())).willReturn(List.of(new PostImage()));
 
 		// When


### PR DESCRIPTION
- 액세스 토큰이 만료되고 리프레시 토큰으로 새로운 액세스 토큰을 생성하면 새로운 액세스 토큰이 정상작동 하지 않았는데 새로운 액세스 토큰을 생성한 후 Redis에 저장하지 않아 발생하는 걸로 확인되어 액세스 토큰을 새로 발급하고 Redis에 저장하는 코드를 추가함
- 사용자가 자신의 게시글이나 댓글만 작성, 수정, 삭제하도록 시큐리티의 권한을 확인하는 로직을 추가하기 위해 userId로 UserAccount 객체를 찾는 메서드를 새로운 클래스로 추출하여 분리하였고, 해당 클래스에 시큐리티에서 username을 가져와 비교하는 로직을 추가함

Related to: #53 